### PR TITLE
会社のHPリンクをFooterに追加

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -39,6 +39,7 @@ const Footer = () => {
                                     <img src={logo} alt="ロゴ" className={styles.logo} />
                                 </Link>
                             </p>
+                            <p><a href="https://jcam.co.jp/"　target="__blank" className={styles.footer_link}><span data-i18n="footer.companyHp">会社概要（運営会社）</span></a></p>
                             <p>105-0011<br /><span data-i18n="footer.companyAddress">東京都港区芝公園4-8-12 猫来坊2階</span></p>
                             <p><a href="https://etherscan.io/address/0x2370f9d504c7a6e775bf6e14b3f12846b594cd53" target="__blank" className={styles.footer_link}>Etherscan</a></p>
                             <p><a href="https://note.com/ocurima/m/mf80a9d72984a" target="__blank" className={styles.footer_link}>JPYC Magazine</a></p>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,6 +13,7 @@
     }
   },
   "footer": {
+    "companyHp": "Company Profile",
     "companyAddress": "4-8-12 Nekoraibo 2F, Shibakoen, Minato Ward, Tokyo",
     "ETHAddress": "ETH Mainnet Contract Address",
     "MaticAddress": "Matic Contract Address",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -13,6 +13,7 @@
     }
   },
   "footer": {
+    "companyHp": "会社概要（運営会社）",
     "companyAddress": "東京都港区芝公園4-8-12 猫来坊2階",
     "ETHAddress": "ETHメインネットコントラクトアドレス",
     "MaticAddress": "Maticコントラクトアドレス",


### PR DESCRIPTION

## 主な変更点
- HPのリンクをFooter左側の最上部に追加
- 日本語の設定ファイルと英語の設定ファイルにそれぞれデータを追加